### PR TITLE
Replace const keyword with var to support ES5

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function setNestedProperty(object, property, value) {
         if (typeof property == "string" && property !== "") {
             var split = property.split(".");
             return split.reduce(function (obj, prop, idx) {
-                const nextPropIsNumber = Number.isInteger(Number(split[idx + 1]));
+                var nextPropIsNumber = Number.isInteger(Number(split[idx + 1]));
                 
                 obj[prop] = obj[prop] || (nextPropIsNumber ? [] : {})
                 if (split.length == (idx + 1)) {


### PR DESCRIPTION
While updating some packages in our project, we found out that this package is using `const` since the latest update.

`SyntaxError: The keyword 'const' is reserved (114:141)`

To fix this, I've simply replaced `const` with `var`